### PR TITLE
Rework StringCommandArgument

### DIFF
--- a/src/main/java/com/github/jvdberg08/commandhandler/argument/StringCommandArgument.java
+++ b/src/main/java/com/github/jvdberg08/commandhandler/argument/StringCommandArgument.java
@@ -1,16 +1,20 @@
 package com.github.jvdberg08.commandhandler.argument;
 
+import org.apache.commons.lang.ArrayUtils;
+
+import java.util.Arrays;
+
 public class StringCommandArgument implements CommandArgument<String> {
 
-    private final String validArgument;
+    private final String[] validArguments;
 
-    public StringCommandArgument(String validArgument) {
-        this.validArgument = validArgument;
+    public StringCommandArgument(String... validArguments) {
+        this.validArguments = validArguments;
     }
 
     @Override
     public boolean checkArgument(String commandArgument, Object[] previousArguments) {
-        return commandArgument.equalsIgnoreCase(validArgument);
+        return ArrayUtils.isEmpty(validArguments) || Arrays.stream(validArguments).anyMatch(commandArgument::equalsIgnoreCase);
     }
 
     @Override


### PR DESCRIPTION
This PR intends to close #1 (except for the enum part, I think the proper way of doing it would be to create a CommandArgument for each enum type), and to allow the arguments to not be pre-determined, which could be useful for command like ```/perm give <player> <string_perm>```.
